### PR TITLE
Remove Python 3.2 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Whoops!

3.2 is tested but isn't supported yet and is an allowed failure.