### PR TITLE
Add utility to run tracery on a JSON file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,5 @@ exclude_lines =
     # Don't complain about debug code
     if Image.DEBUG:
     if DEBUG:
+
+omit = tracery/__main__.py

--- a/tracery/__main__.py
+++ b/tracery/__main__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+Output an example line from a JSON Tracery grammar.
+"""
+from __future__ import print_function, unicode_literals
+import argparse
+import json
+
+import tracery
+from tracery.modifiers import base_english
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Output an example line from a JSON Tracery grammar.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "json", help="Input JSON file")
+    parser.add_argument(
+        "number", type=int, default=1, nargs="?",
+        help="Number of lines to generate")
+    args = parser.parse_args()
+
+    with open(args.json) as data_file:
+        rules = json.load(data_file)
+
+    grammar = tracery.Grammar(rules)
+    grammar.add_modifiers(base_english)
+
+    for i in range(args.number):
+        print(grammar.flatten("#origin#"))
+
+# End of file


### PR DESCRIPTION
Implements #12.

For a package, a \__main__.py file is needed.

Examples:

```
$ python -m tracery potterpapers.json 
Harry Potter and the Tchebyshev transforms of the first and second kind
$ python -m tracery potterpapers.json 3
Harry Potter and the Impact of Extremes in Outdoor Temperature and Sunshine Exposure on Birth Weight.
Harry Potter and the Chromatin Remodelling Enzymes SNF2H and SNF2L Position Nucleosomes adjacent to CTCF and Other Transcription Factors.
Harry Potter and the Model Organism Hermissenda crassicornis (Gastropoda: Heterobranchia) Is a Species Complex.
```

---

If in the `__main__` section of \__init__.py it gives:

```
$ python -mtracery potterpapers.json 
/usr/local/opt/python/bin/python2.7: No module named tracery.__main__; 'tracery' is a package and cannot be directly executed
```
