### PR TITLE
Fixes 'basestring' no longer being available in Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,4 @@ celerybeat-schedule
 .env
 
 # Spyder project settings
-.spyderprojectvenv
-venv
+.spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,5 @@ celerybeat-schedule
 .env
 
 # Spyder project settings
-.spyderproject
+.spyderprojectvenv
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema
+future

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-jsonschema
 future

--- a/tests/test_tracery.py
+++ b/tests/test_tracery.py
@@ -339,6 +339,22 @@ class TestPush(TestPytracery):
         self.assert_ends_with(ret, " closed the book.")
         self.assertEqual(self.grammar.errors, [])
 
+class TestStrings(TestPytracery):
+
+    def test_string_input(self):
+        """The grammar should work properly if the input is a string rather than a list"""
+        # This errored in Py 3.5, taken straight from the README
+        rules = {
+            'origin': '#hello.capitalize#, #location#!',
+            'hello': ['hello'],
+            'location': ['world']
+        }
+
+        grammar = tracery.Grammar(rules)
+        grammar.add_modifiers(base_english)
+        self.assertEqual("Hello, world!", grammar.flatten("#origin#"))
+
+
 
 class TestErrors(TestPytracery):
 

--- a/tracery/__init__.py
+++ b/tracery/__init__.py
@@ -1,6 +1,6 @@
 import re
 import random
-
+from past.builtins import basestring 
 
 class Node(object):
     def __init__(self, parent, child_index, settings):


### PR DESCRIPTION
pytracery's README example wasn't working in Python 3.5, and no test covered that case, so I wrote a test that exposed the problem (`basestring` has been removed from the standard library) and added a test and fix (which requires a new entry in requirements.txt). Tests still pass in 2.7.