### PR TITLE
Drop support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,13 @@ python:
  - 2.7
  - 3.5
  - 2.6
- - 3.2
  - 3.3
  - 3.4
 
 install:
  - pip install -r requirements.txt
+ - pip install coverage
  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
-
- # Coverage 4.0 doesn't support Python 3.2
- - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi
- - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then pip install coverage; fi
 
 script:
  - coverage run --source=tracery -m nose tests/test_*.py

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Many Python libraries are dropping support for Python 3.2, and a dependency of https://github.com/aparrish/pytracery/pull/19 is no longer available for 3.2. CPython 3.2 itself is no longer supported: https://en.wikipedia.org/wiki/CPython#Version_history

So let's drop support here too.