### PR TITLE
Fix for uppercase input

### DIFF
--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -59,6 +59,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "a house")
 
+    def test_a_consonant_uppercase(self):
+        # Arrange
+        text = "HOUSE"
+
+        # Act
+        output = modifiers.a(text)
+
+        # Assert
+        self.assertEqual(output, "a HOUSE")
+
     def test_a_u_something_i(self):
         # Arrange
         text = "unicorn"
@@ -68,6 +78,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "a unicorn")
+
+    def test_a_u_something_i_uppercase(self):
+        # Arrange
+        text = "UNICORN"
+
+        # Act
+        output = modifiers.a(text)
+
+        # Assert
+        self.assertEqual(output, "a UNICORN")
 
     def test_a_u_not_i(self):
         # Arrange
@@ -79,6 +99,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "an underdog")
 
+    def test_a_u_not_i_uppercase(self):
+        # Arrange
+        text = "UNDERDOG"
+
+        # Act
+        output = modifiers.a(text)
+
+        # Assert
+        self.assertEqual(output, "an UNDERDOG")
+
     def test_a_vowel(self):
         # Arrange
         text = "elephant"
@@ -88,6 +118,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "an elephant")
+
+    def test_a_vowel_uppercase(self):
+        # Arrange
+        text = "ELEPHANT"
+
+        # Act
+        output = modifiers.a(text)
+
+        # Assert
+        self.assertEqual(output, "an ELEPHANT")
 
     def test_first_s(self):
         # Arrange
@@ -99,6 +139,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "elephants in a phonebox")
 
+    def test_first_s_uppercase(self):
+        # Arrange
+        text = "ELEPHANT IN A PHONEBOX"
+
+        # Act
+        output = modifiers.firstS(text)
+
+        # Assert
+        self.assertEqual(output, "ELEPHANTs IN A PHONEBOX")
+
     def test_s_ends_in_x(self):
         # Arrange
         text = "box"
@@ -108,6 +158,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "boxes")
+
+#     def test_s_ends_in_x_uppercase(self):
+#         # Arrange
+#         text = "BOX"
+#
+#         # Act
+#         output = modifiers.s(text)
+#
+#         # Assert
+#         self.assertEqual(output, "BOXes")
 
     def test_s_ends_in_non_s(self):
         # Arrange
@@ -119,6 +179,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "goats")
 
+    def test_s_ends_in_non_s_uppercase(self):
+        # Arrange
+        text = "GOAT"
+
+        # Act
+        output = modifiers.s(text)
+
+        # Assert
+        self.assertEqual(output, "GOATs")
+
     def test_s_ends_in_vowel_y(self):
         # Arrange
         text = "monkey"
@@ -128,6 +198,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "monkeys")
+
+    def test_s_ends_in_vowel_y_uppercase(self):
+        # Arrange
+        text = "MONKEY"
+
+        # Act
+        output = modifiers.s(text)
+
+        # Assert
+        self.assertEqual(output, "MONKEYs")
 
     def test_s_ends_in_y_but_not_vowel_y(self):
         # Arrange
@@ -139,6 +219,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "tellies")
 
+#     def test_s_ends_in_y_but_not_vowel_y_uppercase(self):
+#         # Arrange
+#         text = "TELLY"
+#
+#         # Act
+#         output = modifiers.s(text)
+#
+#         # Assert
+#         self.assertEqual(output, "TELLies")
+
     def test_ed_ends_in_e(self):
         # Arrange
         text = "glide"
@@ -148,6 +238,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "glided")
+
+#     def test_ed_ends_in_e_uppercase(self):
+#         # Arrange
+#         text = "GLIDE"
+#
+#         # Act
+#         output = modifiers.ed(text)
+#
+#         # Assert
+#         self.assertEqual(output, "GLIDEd")
 
     def test_ed_ends_in_y_but_not_vowel_y(self):
         # Arrange
@@ -159,6 +259,16 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "shimmied")
 
+#     def test_ed_ends_in_y_but_not_vowel_y_uppercase(self):
+#         # Arrange
+#         text = "SHIMMY"
+#
+#         # Act
+#         output = modifiers.ed(text)
+#
+#         # Assert
+#         self.assertEqual(output, "SHIMMied")
+
     def test_ed_ends_in_non_e_and_non_y(self):
         # Arrange
         text = "jump"
@@ -168,6 +278,16 @@ class TestModifiers(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, "jumped")
+
+    def test_ed_ends_in_non_e_and_non_y_uppercase(self):
+        # Arrange
+        text = "JUMP"
+
+        # Act
+        output = modifiers.ed(text)
+
+        # Assert
+        self.assertEqual(output, "JUMPed")
 
     def test_uppercase(self):
         # Arrange
@@ -179,9 +299,29 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "JUMP UP")
 
+    def test_uppercase_uppercase(self):
+        # Arrange
+        text = "JUMP UP"
+
+        # Act
+        output = modifiers.uppercase(text)
+
+        # Assert
+        self.assertEqual(output, "JUMP UP")
+
     def test_lowercase(self):
         # Arrange
         text = "GET DOWN"
+
+        # Act
+        output = modifiers.lowercase(text)
+
+        # Assert
+        self.assertEqual(output, "get down")
+
+    def test_lowercase_lowercase(self):
+        # Arrange
+        text = "get down"
 
         # Act
         output = modifiers.lowercase(text)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -159,15 +159,15 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "boxes")
 
-#     def test_s_ends_in_x_uppercase(self):
-#         # Arrange
-#         text = "BOX"
-#
-#         # Act
-#         output = modifiers.s(text)
-#
-#         # Assert
-#         self.assertEqual(output, "BOXes")
+    def test_s_ends_in_x_uppercase(self):
+        # Arrange
+        text = "BOX"
+
+        # Act
+        output = modifiers.s(text)
+
+        # Assert
+        self.assertEqual(output, "BOXes")
 
     def test_s_ends_in_non_s(self):
         # Arrange
@@ -219,15 +219,15 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "tellies")
 
-#     def test_s_ends_in_y_but_not_vowel_y_uppercase(self):
-#         # Arrange
-#         text = "TELLY"
-#
-#         # Act
-#         output = modifiers.s(text)
-#
-#         # Assert
-#         self.assertEqual(output, "TELLies")
+    def test_s_ends_in_y_but_not_vowel_y_uppercase(self):
+        # Arrange
+        text = "TELLY"
+
+        # Act
+        output = modifiers.s(text)
+
+        # Assert
+        self.assertEqual(output, "TELLies")
 
     def test_ed_ends_in_e(self):
         # Arrange
@@ -239,15 +239,15 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "glided")
 
-#     def test_ed_ends_in_e_uppercase(self):
-#         # Arrange
-#         text = "GLIDE"
-#
-#         # Act
-#         output = modifiers.ed(text)
-#
-#         # Assert
-#         self.assertEqual(output, "GLIDEd")
+    def test_ed_ends_in_e_uppercase(self):
+        # Arrange
+        text = "GLIDE"
+
+        # Act
+        output = modifiers.ed(text)
+
+        # Assert
+        self.assertEqual(output, "GLIDEd")
 
     def test_ed_ends_in_y_but_not_vowel_y(self):
         # Arrange
@@ -259,15 +259,15 @@ class TestModifiers(unittest.TestCase):
         # Assert
         self.assertEqual(output, "shimmied")
 
-#     def test_ed_ends_in_y_but_not_vowel_y_uppercase(self):
-#         # Arrange
-#         text = "SHIMMY"
-#
-#         # Act
-#         output = modifiers.ed(text)
-#
-#         # Assert
-#         self.assertEqual(output, "SHIMMied")
+    def test_ed_ends_in_y_but_not_vowel_y_uppercase(self):
+        # Arrange
+        text = "SHIMMY"
+
+        # Act
+        output = modifiers.ed(text)
+
+        # Assert
+        self.assertEqual(output, "SHIMMied")
 
     def test_ed_ends_in_non_e_and_non_y(self):
         # Arrange

--- a/tracery/modifiers.py
+++ b/tracery/modifiers.py
@@ -27,10 +27,10 @@ def firstS(text, *params):
 
 
 def s(text, *params):
-    if text[-1] in 'shx':
+    if text[-1].lower() in 'shx':
         return text + "es"
-    elif text[-1] == 'y':
-        if text[-2] not in "aeiou":
+    elif text[-1].lower() == 'y':
+        if text[-2].lower() not in "aeiou":
             return text[:-1] + "ies"
         else:
             return text + "s"
@@ -39,10 +39,10 @@ def s(text, *params):
 
 
 def ed(text, *params):
-    if text[-1] == 'e':
+    if text[-1].lower() == 'e':
         return text + "d"
-    elif text[-1] == 'y':
-        if text[-2] not in "aeiou":
+    elif text[-1].lower() == 'y':
+        if text[-2].lower() not in "aeiou":
             return text[:-1] + "ied"
     else:
         return text + "ed"

--- a/tracery/modifiers.py
+++ b/tracery/modifiers.py
@@ -12,11 +12,11 @@ def capitalize_(text, *params):
 
 def a(text, *params):
     if len(text) > 0:
-        if text[0].lower() == 'u':
+        if text[0] in "uU":
             if len(text) > 2:
-                if text[2].lower() == 'i':
+                if text[2] in "iI":
                     return "a " + text
-        if text[0].lower() in "aeiou":
+        if text[0] in "aeiouAEIOU":
             return "an " + text
     return "a " + text
 
@@ -27,10 +27,10 @@ def firstS(text, *params):
 
 
 def s(text, *params):
-    if text[-1].lower() in 'shx':
+    if text[-1] in "shxSHX":
         return text + "es"
-    elif text[-1].lower() == 'y':
-        if text[-2].lower() not in "aeiou":
+    elif text[-1] in "yY":
+        if text[-2] not in "aeiouAEIOU":
             return text[:-1] + "ies"
         else:
             return text + "s"
@@ -39,10 +39,10 @@ def s(text, *params):
 
 
 def ed(text, *params):
-    if text[-1].lower() == 'e':
+    if text[-1] in "eE":
         return text + "d"
-    elif text[-1].lower() == 'y':
-        if text[-2].lower() not in "aeiou":
+    elif text[-1] in "yY":
+        if text[-2] not in "aeiouAEIOU":
             return text[:-1] + "ied"
     else:
         return text + "ed"


### PR DESCRIPTION
I spotted only some of the modifiers were taking care of both upper and lowercase input.

Here's unit tests for them, and those which work for uppercase input, and fixes.

Also, it's nearly twice as fast to do `c in in "aeiouAEIOU"` than `c.lower() in "aeiou"`, and I don't think it loses anything in readability.