### PR TITLE
Python 2 fix for when a Unicode rule is not found

### DIFF
--- a/tests/test_tracery.py
+++ b/tests/test_tracery.py
@@ -353,7 +353,12 @@ class TestPush(TestPytracery):
         # Assert
         self.assertIn(" opened a book about a", ret)
         self.assert_ends_with(ret, " closed the book.")
-        self.assertEqual(self.grammar.errors, [])
+        self.assertEqual(
+            self.grammar.errors,
+            ['No symbol for hero', 'No symbol for occupation',
+             'No symbol for heroTheir', 'No symbol for hero',
+             'No symbol for didStuff', 'No symbol for heroThey',
+             'No symbol for didStuff', 'No symbol for heroThey'])
 
 
 class TestStrings(TestPytracery):
@@ -417,7 +422,7 @@ class TestErrors(TestPytracery):
 
         # Assert
         self.assertEqual(ret, "((unicorns))")
-        self.assertEqual(self.grammar.errors, [])
+        self.assertEqual(self.grammar.errors, ["No symbol for unicorns"])
 
     def test_missing_right_bracket(self):
         # Arrange
@@ -466,8 +471,9 @@ class TestErrors(TestPytracery):
         self.assertEqual(ret, "][][((None))][][[]]]]")
         self.assertEqual(
             self.grammar.errors,
-            ["unclosed tag", "1: empty tag", "1: empty action",
-             "10: empty tag", "unclosed tag", "too many ]"])
+            ['unclosed tag', 'No symbol for None', 'No symbol for None',
+            '1: empty tag', '1: empty action', '10: empty tag', 'unclosed tag',
+            'too many ]'])
 
 
 if __name__ == "__main__":

--- a/tests/test_tracery.py
+++ b/tests/test_tracery.py
@@ -472,8 +472,8 @@ class TestErrors(TestPytracery):
         self.assertEqual(
             self.grammar.errors,
             ['unclosed tag', 'No symbol for None', 'No symbol for None',
-            '1: empty tag', '1: empty action', '10: empty tag', 'unclosed tag',
-            'too many ]'])
+             '1: empty tag', '1: empty action', '10: empty tag',
+             'unclosed tag', 'too many ]'])
 
 
 if __name__ == "__main__":

--- a/tests/test_tracery.py
+++ b/tests/test_tracery.py
@@ -232,6 +232,20 @@ class TestWebSpecifics(TestPytracery):
         self.assertEqual(ret, "&#x2665; &#x2614; &#9749; &#x2665;")
         self.assertEqual(self.grammar.errors, [])
 
+    def test_unicode_rule_not_found(self):
+        # Arrange
+        rules = {
+            'origin': '#пправило#',
+            'rule not found': 'something',
+        }
+        grammar_rule_not_found = tracery.Grammar(rules)
+
+        # Act
+        ret = grammar_rule_not_found.flatten("#origin#")
+
+        # Assert
+        self.assertEqual(ret, "((пправило))")
+
     def test_svg(self):
         # Arrange
         src = ('<svg width="100" height="70">'

--- a/tests/test_tracery.py
+++ b/tests/test_tracery.py
@@ -245,6 +245,8 @@ class TestWebSpecifics(TestPytracery):
 
         # Assert
         self.assertEqual(ret, "((пправило))")
+        self.assertEqual(grammar_rule_not_found.errors,
+                         ["No symbol for пправило"])
 
     def test_svg(self):
         # Arrange

--- a/tracery/__init__.py
+++ b/tracery/__init__.py
@@ -227,7 +227,8 @@ class Grammar(object):
         self.symbols = dict()
         self.subgrammars = list()
         if raw:
-            self.symbols = dict((k, Symbol(self, k, v)) for k, v in raw.items())
+            self.symbols = dict(
+                (k, Symbol(self, k, v)) for k, v in raw.items())
 
     def create_root(self, rule):
         return Node(self, 0, {'type': -1, 'raw': rule})
@@ -260,8 +261,10 @@ class Grammar(object):
         if key in self.symbols:
             return self.symbols[key].select_rule(node, errors)
         else:
-            errors.append("No symbol for " + str(key))
-            return "((" + str(key) + "))"
+            if key is None:
+                key = str(None)
+            errors.append("No symbol for " + key)
+            return "((" + key + "))"
 
 
 def parse_tag(tag_contents):

--- a/tracery/__init__.py
+++ b/tracery/__init__.py
@@ -263,7 +263,7 @@ class Grammar(object):
         else:
             if key is None:
                 key = str(None)
-            errors.append("No symbol for " + key)
+            self.errors.append("No symbol for " + key)
             return "((" + key + "))"
 
 

--- a/tracery/modifiers.py
+++ b/tracery/modifiers.py
@@ -55,6 +55,7 @@ def uppercase(text, *params):
 def lowercase(text, *params):
     return text.lower()
 
+
 base_english = {
     'replace': replace,
     'capitalizeAll': capitalizeAll,


### PR DESCRIPTION
Fixes #29.

The root cause is trying to do something like `str(unicode("пправило"))`, which isn't a problem in Python 3.