### PR TITLE
Use Python 3 print in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ otherwise.
 
     grammar = tracery.Grammar(rules)
     grammar.add_modifiers(base_english)
-    print grammar.flatten("#origin#") # prints, e.g., "Hello, world!"
+    print(grammar.flatten("#origin#"))  # prints, e.g., "Hello, world!"
 
 Any valid Tracery grammar should work in this port. The ``base_english``
 modifiers in ``tracery.modifiers`` are a port of the modifiers in the JavaScript


### PR DESCRIPTION
Most are using Python 3 now, default to Python 3-style `print` for easier copying and pasting.