### PR TITLE
Changed tutorial link to archived page for now.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Usage
 -----
 
 See `Kate Compton's Tracery
-tutorial <http://www.crystalcodepalace.com/traceryTut.html>`_ for information
+tutorial <https://web.archive.org/web/20190324081511/http://www.crystalcodepalace.com:80/traceryTut.html>`_ for information
 about how Tracery works. In the Python port, you use Python dictionaries
 instead of JavaScript objects for the rules, but the concept is the same
 otherwise.


### PR DESCRIPTION
Looks like someone else owns Kate's old domain. I opened it on my phone and had a bunch of alerts thrown in my face. I changed the link to an archived page so that no one else has to have the same experience. Unfortunately, even https://tracery.io/ still points to the old domain.